### PR TITLE
Change default naming strategy

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -53,6 +53,7 @@ doctrine:
     orm:
         auto_generate_proxy_classes: %kernel.debug%
         auto_mapping: true
+        naming_strategy: doctrine.orm.naming_strategy.underscore
 
 # Swiftmailer Configuration
 swiftmailer:


### PR DESCRIPTION
As we generally use this naming strategy in our projets,
maybe we can set it as the default one.
