### PR TITLE
Added project type to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "The \"KnpLabs Symfony2 Rad Edition\"",
     "keywords": ["Symfony2", "Symfony2 Rad Edition", "Symfony2 Distribution"],
     "license":     "MIT",
+    "type": "project",
     "homepage": "http://rad.knplabs.com",
     "authors": [
         {


### PR DESCRIPTION
Some IDE plugins like https://github.com/pulse00/Composer-Eclipse-Plugin show filtered composer packages by the type project in their project wizards.

This PR will make the Knp Rad edition show up in these dialogs.
