### PR TITLE
[WIP] composer "extra config package" based bundle registration

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -2,6 +2,7 @@
 
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 class AppKernel extends Kernel
 {
@@ -24,6 +25,24 @@ class AppKernel extends Kernel
         if (in_array($this->getEnvironment(), array('dev', 'test'))) {
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
+        }
+
+        $bundles = array_merge($bundles, $this->autoDiscoverBundles());
+
+        return $bundles;
+    }
+
+    private function autoDiscoverBundles()
+    {
+        $bundles = array();
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(__DIR__.'/bundles')) as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+            $bundle = require $file->getRealPath();
+            if ($bundle instanceof BundleInterface) {
+                $bundles[] = $bundle;
+            }
         }
 
         return $bundles;

--- a/app/Composer/RegisterBundle.php
+++ b/app/Composer/RegisterBundle.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Knp\RadBundle\Composer;
+
+use Composer\Script\PackageEvent;
+use Composer\Script\Event;
+use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\Package\PackageInterface;
+
+class RegisterBundle
+{
+    public static function postPackageInstall(PackageEvent $event)
+    {
+        $operation = $event->getOperation();
+        if (!$operation instanceof InstallOperation) {
+            return;
+        }
+
+        $package = $operation->getPackage();
+        self::registerWithConfig($event, $package);
+    }
+
+    public static function registerWithConfig(PackageEvent $event, PackageInterface $package)
+    {
+        $packageOptions = $package->getExtra();
+        if (!isset($packageOptions['register-bundles'])) {
+            return;
+        }
+
+        $options = self::getOptions($event);
+        $registerPath = sprintf('%s/%s',
+            getcwd(),
+            $options['symfony-app-dir'].'/bundles'
+        );
+
+        $classes = (array)$packageOptions['register-bundles'];
+        foreach ($classes as $class) {
+            $path = $registerPath.'/'.$package->getPrettyName();
+            @mkdir(dirname($path), 0777, true);
+            file_put_contents(
+                $path,
+                sprintf('<?php return new %s($this);', $class)
+            );
+        }
+    }
+
+    protected static function getOptions(Event $event)
+    {
+        $options = array_merge(array(
+            'symfony-app-dir' => 'app',
+            'symfony-web-dir' => 'web',
+        ), $event->getComposer()->getPackage()->getExtra());
+
+        return $options;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "bin-dir": "bin"
     },
     "autoload": {
-        "psr-0": { "": "src/", "Context": "features/" }
+        "psr-0": { "": "src/", "Context": "features/" },
+        "files": ["app/Composer/RegisterBundle.php"]
     },
      "scripts": {
         "post-install-cmd": [
@@ -53,6 +54,12 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
+        ],
+        "post-package-install": [
+            "RegisterBundle::postPackageInstall"
+        ],
+        "post-package-uninstall": [
+            "RegisterBundle::postPackageInstall"
         ]
     },
     "extra": {


### PR DESCRIPTION
Every library package that has configured the specified key in its
`extra` config will be registered automatically:

``` json

{
    "name": "vendor/foo-bundle",
    "extra": {
        "register-bundles": ["Vendor\Bundle\VendorFooBundle"]
    }
}

```

The effect is to create a file at path `app/bundle/vendor/foo-bundle` that
contains php code to instanciate the bundle:

``` php

<?php return new \Vendor\Bundle\VendorFooBundle($this);

```

The bundle always receive the kernel as first and only constructor argument.

A Kernel impl. may then be able to auto-discover and `require` these
files to append them to its list of registered bundles.
