### PR TITLE
Fixing FeatureContext template to work with last updates of Behat

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -4,7 +4,7 @@ default:
     suites:
         default:
             path: %paths.base%/features
-            contexts: [FeatureContext, Behat\MinkExtension\Context\MinkContext]
+            contexts: [Context\FeatureContext, Behat\MinkExtension\Context\MinkContext]
     extensions:
         Behat\MinkExtension\Extension:
             base_url:    'http://localhost:8080/app_test.php'

--- a/features/Context/FeatureContext.php
+++ b/features/Context/FeatureContext.php
@@ -2,9 +2,9 @@
 
 namespace Context;
 
-use Behat\Behat\Context\ContextInterface;
-use Behat\Behat\Snippet\Context\TurnipSnippetsFriendlyInterface;
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
 
-class FeatureContext implements ContextInterface, TurnipSnippetsFriendlyInterface
+class FeatureContext implements Context, SnippetAcceptingContext
 {
 }


### PR DESCRIPTION
When installing from composer create-project, `bin/behat` would not work because changes had been made to base context and turnip context class names.
