### PR TITLE
Unlock rad bundle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "doctrine/orm": "~2.4",
         "doctrine/doctrine-bundle": "~1.2",
         "sensio/distribution-bundle": "2.3.*",
-        "knplabs/rad-bundle": "2.3.1",
+        "knplabs/rad-bundle": "~2.5",
         "twig/extensions": "~1.0",
         "symfony/assetic-bundle": "~2.3",
         "doctrine/doctrine-fixtures-bundle": "~2.1@dev",


### PR DESCRIPTION
The latest version of RAD Bundle should be installed, shouldn't it?
And also RAD Edition is not usable from scratch because of https://github.com/KnpLabs/KnpRadBundle/issues/177
