### PR TITLE
Fix createAccessDenied visibility method issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony": "~2.4",
+        "symfony/symfony": "2.4.*",
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.4",
         "doctrine/orm": "~2.4",


### PR DESCRIPTION
When using SF 2.5, there is a visibility method issue.

RadBundle v2.3.1 `protected function createAccessDeniedException(...)`
Symfony v2.5 `public function createAccessDeniedException(...)`

This problem is fixed in the RadBundle dev-master, but no tag has been created. So here is a fix until the tag is created.
